### PR TITLE
New option: g:PyFlakeForcePyVersion

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -74,6 +74,10 @@ Maximum line length for PyFlakeAuto command
 Visual-mode key command for PyFlakeAuto
 
     let g:PyFlakeRangeCommand = 'Q'
+
+Force python 3 interface:
+
+    let g:PyFlakeForcePyVersion = 3
     
 ## Commands
 

--- a/ftplugin/python/flake8.vim
+++ b/ftplugin/python/flake8.vim
@@ -4,7 +4,7 @@ if !has('python') && !has('python3')
     finish
 endif
 
-let s:pycmd = has('python') ? ':py' : ':py3'
+let s:pycmd = has('python') && (!exists('g:PyFlakeForcePyVersion') || g:PyFlakeForcePyVersion != 3) ? ':py' : ':py3'
 " This is the last sign used, so that we can remove them individually.
 let s:last_sign = 1
 


### PR DESCRIPTION
If Vim is compiled with both if_py and if_py3, the latest version of flake8-vim always use if_py interface.
I add an option to specify python version in such a case.

To use if_py3 interface:

```vim
let g:PyFlakeForcePyVersion = 3
```