### PR TITLE
Pass relevant options to pep8 when running checks

### DIFF
--- a/ftplugin/python/flake8.py
+++ b/ftplugin/python/flake8.py
@@ -182,7 +182,10 @@ def _init_pep8():
         def get_file_results(self):
             return self.errors
 
-    PEP8 = p8.StyleGuide(reporter=_PEP8Report)
+    PEP8 = p8.StyleGuide(reporter=_PEP8Report,
+                         ignore=Pep8Options.ignore,
+                         select=Pep8Options.select,
+                         max_line_length=Pep8Options.max_line_length)
     return PEP8
 
 

--- a/ftplugin/python/flake8.vim
+++ b/ftplugin/python/flake8.vim
@@ -57,7 +57,7 @@ if !exists('g:PyFlakeDefaultComplexity')
     let g:PyFlakeDefaultComplexity=10
 endif
 if !exists('g:PyFlakeDisabledMessages')
-    let g:PyFlakeDisabledMessages = 'E501'
+    let g:PyFlakeDisabledMessages = ''
 endif
 if !exists('g:PyFlakeCWindow')
     let g:PyFlakeCWindow = 6
@@ -74,7 +74,7 @@ if !exists('g:PyFlakeAggressive')
     let g:PyFlakeAggressive = 0
 endif
 if !exists('g:PyFlakeMaxLineLength')
-    let g:PyFlakeMaxLineLength = 100
+    let g:PyFlakeMaxLineLength = 79
 endif
 if !exists('g:PyFlakeLineIndentGlitch')
     let g:PyFlakeLineIndentGlitch = 1


### PR DESCRIPTION
g:Flake8MaxLineLength and g:PyFlakeDisabledMessages weren't passed to pep8 when checking a file (though disabled messages got filtered out within flake8).  Since line length checks now work, don't turn them off by default and set the default max length to 79 since that's the normal pep8 default.