### PR TITLE
Fix pep8

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,9 +4,9 @@
 [submodule "ftplugin/python/autopep8"]
 	path = ftplugin/python/autopep8
 	url = https://github.com/hhatto/autopep8.git
-[submodule "ftplugin/python/pep8"]
-	path = ftplugin/python/pep8
-	url = https://github.com/jcrocholl/pep8.git
+[submodule "ftplugin/python/pycodestyle"]
+	path = ftplugin/python/pycodestyle
+	url = https://github.com/PyCQA/pycodestyle.git
 [submodule "ftplugin/python/frosted"]
 	path = ftplugin/python/frosted
 	url = https://github.com/timothycrosley/frosted.git

--- a/ftplugin/python/flake8.py
+++ b/ftplugin/python/flake8.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-SUBMODULES = ['mccabe', 'pep8', 'autopep8', 'frosted', 'pies']
+SUBMODULES = ['mccabe', 'pycodestyle', 'autopep8', 'frosted', 'pies']
 
 import sys
 import os
@@ -15,7 +15,7 @@ from mccabe import McCabeChecker
 from frosted.api import checker, _noqa_lines
 from frosted import messages
 import _ast
-import pep8 as p8
+import pycodestyle as p8
 from autopep8 import fix_file as pep8_fix, fix_lines as pep8_fix_lines, DEFAULT_INDENT_SIZE, continued_indentation as autopep8_c_i
 from contextlib import contextmanager
 from operator import attrgetter


### PR DESCRIPTION
I found jcrocholl/pep8 has been renamed to PyCQA/pycodestyle .
So I replaced pep8 with pycodestyle.